### PR TITLE
Support for cordova-android >= 10.0.0

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     id="gopay-plugin-hostedwebapp"
-    version="0.4.0">
+    version="0.5.0">
     <name>HostedWebApp</name>
     <description>Hosted Web App Plugin</description>
     <license>MIT License</license>
@@ -9,7 +9,6 @@
     <repo>https://github.com/crux153/ManifoldCordova.git</repo>
     <issue>https://github.com/crux153/ManifoldCordova/issues</issue>
 
-    <dependency id="cordova-plugin-whitelist" version=">=1.0.1" />
     <dependency id="cordova-plugin-network-information" version=">=1.0.0" />
 
     <hook type="before_prepare" src="scripts/updateConfigurationBeforePrepare.js" />
@@ -24,6 +23,7 @@
     <asset src="www/hostedapp-bridge.js" target="hostedapp-bridge.js" />
 
     <engines>
+        <engine name="cordova-android" version=">=10.0.0" />
         <engine name="cordova-ios" version=">=6.0.0" />
     </engines>
 

--- a/src/android/HostedWebApp.java
+++ b/src/android/HostedWebApp.java
@@ -11,12 +11,13 @@ import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.LinearLayout;
 
+import org.apache.cordova.AllowList;
+import org.apache.cordova.AllowListPlugin;
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaActivity;
 import org.apache.cordova.CordovaPlugin;
-
 import org.apache.cordova.PluginResult;
-import org.apache.cordova.Whitelist;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -369,12 +370,12 @@ public class HostedWebApp extends CordovaPlugin {
         }
 
         if (match.length() > 0) {
-            Whitelist whitelist = new Whitelist();
+            AllowList whitelist = new AllowList();
             for (int j = 0; j < match.length(); j++) {
-                whitelist.addWhiteListEntry(match.optString(j).trim(), false);
+                whitelist.addAllowListEntry(match.optString(j).trim(), false);
             }
 
-            isURLMatch = whitelist.isUrlWhiteListed(pageUrl);
+            isURLMatch = whitelist.isUrlAllowListed(pageUrl);
         }
 
         return isURLMatch;
@@ -386,7 +387,7 @@ public class HostedWebApp extends CordovaPlugin {
 
     private CordovaPlugin getWhitelistPlugin() {
         if (this.whiteListPlugin == null) {
-            this.whiteListPlugin = this.webView.getPluginManager().getPlugin("Whitelist");
+            this.whiteListPlugin = this.webView.getPluginManager().getPlugin(AllowListPlugin.PLUGIN_NAME);
         }
 
         return whiteListPlugin;


### PR DESCRIPTION
add/fix: in cordova-android 10.0.0 the whitelist plugin was integrated in cordova-android itself (same as was already the case for iOS) and at the same time everything was renamed from whitelist to allowlist; since this plugin uses it directly, the code had to be updated; as a result this plugin now requires cordova-android >= 10.0.0